### PR TITLE
Configurable entity mappings

### DIFF
--- a/src/Knp/JsonSchemaBundle/DependencyInjection/Compiler/RegisterMappingsPass.php
+++ b/src/Knp/JsonSchemaBundle/DependencyInjection/Compiler/RegisterMappingsPass.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Knp\JsonSchemaBundle\DependencyInjection\Compiler;
+
+use Doctrine\Common\Annotations\Reader;
+use Knp\JsonSchemaBundle\Schema\SchemaRegistry;
+use Knp\JsonSchemaBundle\Schema\ReflectionFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class RegisterMappingsPass implements CompilerPassInterface
+{
+    protected $bundle;
+
+    public function process(ContainerBuilder $container)
+    {
+        if (
+            !$container->hasDefinition('json_schema.registry') ||
+            !$container->has('annotation_reader') ||
+            !$container->has('json_schema.reflection_factory')
+        ) {
+            return;
+        }
+
+        $registry = $container->getDefinition('json_schema.registry');
+        $reader   = $container->get('annotation_reader');
+        $factory  = $container->get('json_schema.reflection_factory');
+
+        $mappings = $container->getParameter('json_schema.mappings');
+
+        foreach ($mappings as $mapping) {
+            if (isset($mapping['dir']) && isset($mapping['prefix'])) {
+                /** @var \ReflectionClass[] $refClasses */
+                $refClasses = $factory->createFromDirectory(
+                    $mapping['dir'],
+                    $mapping['prefix']
+                );
+
+                foreach ($refClasses as $refClass) {
+                    foreach ($reader->getClassAnnotations($refClass) as $annotation) {
+                        if ($annotation instanceof \Knp\JsonSchemaBundle\Annotations\Schema) {
+                            $alias = $annotation->name ?: strtolower($refClass->getShortName());
+                            $registry->addMethodCall('register', [$alias, $refClass->getName()]);
+                        }
+                    }
+                }
+            } elseif (isset($mapping['class'])) {
+                $refClass = new \ReflectionClass($mapping['class']);
+                foreach ($reader->getClassAnnotations($refClass) as $annotation) {
+                    if ($annotation instanceof \Knp\JsonSchemaBundle\Annotations\Schema) {
+                        $alias = $annotation->name ?: strtolower($refClass->getShortName());
+                        $registry->addMethodCall('register', [$alias, $refClass->getName()]);
+                    }
+                }
+            } else {
+                throw new \RuntimeException("Invalid mapping configuration!");
+            }
+        }
+    }
+}

--- a/src/Knp/JsonSchemaBundle/DependencyInjection/Configuration.php
+++ b/src/Knp/JsonSchemaBundle/DependencyInjection/Configuration.php
@@ -29,6 +29,15 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('The db driver %s is not supported. Please choose one of ' . implode(', ', $this->supportedDbDrivers))
                     ->end()
                 ->end()
+                ->arrayNode('mappings')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('dir')->end()
+                            ->scalarNode('prefix')->end()
+                            ->scalarNode('class')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Knp/JsonSchemaBundle/DependencyInjection/KnpJsonSchemaExtension.php
+++ b/src/Knp/JsonSchemaBundle/DependencyInjection/KnpJsonSchemaExtension.php
@@ -22,5 +22,6 @@ class KnpJsonSchemaExtension extends Extension
 
         $guesserService = $config['db_driver'] === 'orm' ? 'form.type_guesser.doctrine' : 'form.type_guesser.doctrine.mongodb';
         $container->setAlias('json_schema.guesser', $guesserService, false);
+        $container->setParameter('json_schema.mappings', $config['mappings']);
     }
 }

--- a/src/Knp/JsonSchemaBundle/KnpJsonSchemaBundle.php
+++ b/src/Knp/JsonSchemaBundle/KnpJsonSchemaBundle.php
@@ -16,5 +16,6 @@ class KnpJsonSchemaBundle extends Bundle
         }
 
         $container->addCompilerPass(new Compiler\RegisterPropertyHandlersPass());
+        $container->addCompilerPass(new Compiler\RegisterMappingsPass());
     }
 }

--- a/src/Knp/JsonSchemaBundle/Schema/SchemaRegistry.php
+++ b/src/Knp/JsonSchemaBundle/Schema/SchemaRegistry.php
@@ -8,7 +8,7 @@ class SchemaRegistry
 
     public function register($alias, $namespace)
     {
-        if ($this->hasAlias($alias)) {
+        if ($this->hasAlias($alias) && $namespace !== $this->getNamespace($alias)) {
             throw new \Exception(sprintf(
                 'Alias "%s" is already used for namespace "%s".',
                 $alias,
@@ -16,7 +16,7 @@ class SchemaRegistry
             ));
         }
 
-        if ($this->hasNamespace($namespace)) {
+        if ($this->hasNamespace($namespace) && $alias !== $this->getAlias($namespace)) {
             throw new \Exception(sprintf(
                 'Namespace "%s" is already registered with alias "%s".',
                 $namespace,


### PR DESCRIPTION
This will allow for semantic configuration like the following:
```
knp_json_schema:
    mappings:
        - { prefix: Lemon\Model, dir: %kernel.root_dir%/../src/Lemon/Model }
        - { class: \Lemon\Model\Foobar }
```

It still relies upon the annotation for configuration information, but the big advantage here is that you can do a bundle-less sf2 application like Ryan Weaver recently blogged about.